### PR TITLE
Modernize S2A frame protector tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5698,6 +5698,7 @@ targets:
   - gpr
   - grpc
 - name: s2a_frame_protector_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -5715,6 +5716,7 @@ targets:
   - grpc_test_util
   - grpc
 - name: s2a_record_protocol_test
+  gtest: true
   build: test
   language: c++
   src:

--- a/test/core/tsi/s2a/BUILD
+++ b/test/core/tsi/s2a/BUILD
@@ -65,6 +65,7 @@ grpc_cc_test(
     name = "s2a_frame_protector_test",
     srcs = ["s2a_frame_protector_test.cc"],
     external_deps = [
+        "gtest",
         "libssl",
     ],
     language = "C++",

--- a/test/core/tsi/s2a/s2a_frame_protector_test.cc
+++ b/test/core/tsi/s2a/s2a_frame_protector_test.cc
@@ -16,11 +16,13 @@
  *
  */
 
+#include <gmock/gmock.h>
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+#include <gtest/gtest.h>
 #include <openssl/ssl3.h>
 #include <vector>
 
@@ -35,12 +37,75 @@
 #include "test/core/tsi/s2a/s2a_test_data.h"
 #include "test/core/tsi/s2a/s2a_test_util.h"
 
-static void s2a_zero_copy_grpc_protector_create_test(uint16_t ciphersuite) {
+namespace testing {
+
+class S2AFrameProtectorTest : public TestWithParam<uint16_t> {
+ protected:
+  S2AFrameProtectorTest() {}
+
+  void SetUp() override { channel_ = new grpc_channel(); }
+
+  void TearDown() override {
+    if (error_details_ != nullptr) {
+      gpr_free(error_details_);
+      error_details_ = nullptr;
+    }
+    if (protector_ != nullptr) {
+      tsi_zero_copy_grpc_protector_destroy(protector_);
+      protector_ = nullptr;
+    }
+    delete channel_;
+  }
+
+  bool InitializeProtector() {
+    uint8_t* traffic_secret;
+    size_t traffic_secret_size;
+    switch (GetParam()) {
+      case kTlsAes128GcmSha256:
+        traffic_secret = s2a_test_data::aes_128_gcm_traffic_secret.data();
+        traffic_secret_size = s2a_test_data::aes_128_gcm_traffic_secret.size();
+        break;
+      case kTlsAes256GcmSha384:
+        traffic_secret = s2a_test_data::aes_256_gcm_traffic_secret.data();
+        traffic_secret_size = s2a_test_data::aes_256_gcm_traffic_secret.size();
+        break;
+      case kTlsChacha20Poly1305Sha256:
+        traffic_secret = s2a_test_data::chacha_poly_traffic_secret.data();
+        traffic_secret_size = s2a_test_data::chacha_poly_traffic_secret.size();
+        break;
+      default:
+        gpr_log(GPR_ERROR, kS2AUnsupportedCiphersuite);
+        abort();
+    }
+    bool is_chacha_poly = (GetParam() == kTlsChacha20Poly1305Sha256);
+    tsi_result expected_result = is_chacha_poly ? TSI_UNIMPLEMENTED : TSI_OK;
+    EXPECT_EQ(
+        s2a_zero_copy_grpc_protector_create(
+            /* TLS 1.3=*/0, GetParam(), traffic_secret, traffic_secret_size,
+            traffic_secret, traffic_secret_size, channel_, &protector_),
+        expected_result);
+    if (is_chacha_poly) {
+      return false;
+    }
+    EXPECT_NE(protector_, nullptr);
+    return true;
+  }
+
+  grpc_channel* channel_ = nullptr;
+  char* error_details_ = nullptr;
+  tsi_zero_copy_grpc_protector* protector_ = nullptr;
+};
+
+INSTANTIATE_TEST_SUITE_P(S2AFrameProtectorTest, S2AFrameProtectorTest,
+                         Values(kTlsAes128GcmSha256, kTlsAes256GcmSha384,
+                                kTlsChacha20Poly1305Sha256));
+
+TEST_P(S2AFrameProtectorTest, Create) {
   grpc_core::ExecCtx exec_ctx;
   uint8_t* traffic_secret;
   size_t traffic_secret_size;
   size_t tag_size;
-  switch (ciphersuite) {
+  switch (GetParam()) {
     case kTlsAes128GcmSha256:
       traffic_secret = s2a_test_data::aes_128_gcm_traffic_secret.data();
       traffic_secret_size = s2a_test_data::aes_128_gcm_traffic_secret.size();
@@ -60,128 +125,88 @@ static void s2a_zero_copy_grpc_protector_create_test(uint16_t ciphersuite) {
       gpr_log(GPR_ERROR, kS2AUnsupportedCiphersuite);
       abort();
   }
-  tsi_zero_copy_grpc_protector* protector = nullptr;
-  grpc_channel* channel = new grpc_channel();
 
   /** Attempt to create an s2a_zero_copy_grpc_protector instance using
    *  nullptr arguments. **/
   tsi_result create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size,
-      traffic_secret, traffic_secret_size, channel, /* protector=*/nullptr);
-  GPR_ASSERT(create_result == TSI_INVALID_ARGUMENT);
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size,
+      traffic_secret, traffic_secret_size, channel_, /* protector=*/nullptr);
+  EXPECT_EQ(create_result, TSI_INVALID_ARGUMENT);
 
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, /* in_traffic_secret=*/nullptr,
-      traffic_secret_size, traffic_secret, traffic_secret_size, channel,
-      &protector);
-  GPR_ASSERT(create_result == TSI_INVALID_ARGUMENT);
+      /* tls_version=*/0, GetParam(), /* in_traffic_secret=*/nullptr,
+      traffic_secret_size, traffic_secret, traffic_secret_size, channel_,
+      &protector_);
+  EXPECT_EQ(create_result, TSI_INVALID_ARGUMENT);
 
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size,
-      /* out_traffic_secret=*/nullptr, traffic_secret_size, channel,
-      &protector);
-  GPR_ASSERT(create_result == TSI_INVALID_ARGUMENT);
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size,
+      /* out_traffic_secret=*/nullptr, traffic_secret_size, channel_,
+      &protector_);
+  EXPECT_EQ(create_result, TSI_INVALID_ARGUMENT);
 
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size,
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size,
       traffic_secret, traffic_secret_size,
-      /* channel=*/nullptr, &protector);
-  GPR_ASSERT(create_result == TSI_INVALID_ARGUMENT);
-  GPR_ASSERT(protector == nullptr);
+      /* channel=*/nullptr, &protector_);
+  EXPECT_EQ(create_result, TSI_INVALID_ARGUMENT);
+  EXPECT_EQ(protector_, nullptr);
 
   /** Attempt to create an s2a_zero_copy_grpc_protector instance using
    *  an invalid TLS version. **/
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/1, ciphersuite, traffic_secret, traffic_secret_size,
-      traffic_secret, traffic_secret_size, channel, &protector);
-  GPR_ASSERT(create_result == TSI_FAILED_PRECONDITION);
-  GPR_ASSERT(protector == nullptr);
+      /* tls_version=*/1, GetParam(), traffic_secret, traffic_secret_size,
+      traffic_secret, traffic_secret_size, channel_, &protector_);
+  EXPECT_EQ(create_result, TSI_FAILED_PRECONDITION);
+  EXPECT_EQ(protector_, nullptr);
 
   /** Attempt to create an s2a_zero_copy_grpc_protector instance using
    *  incorrect key sizes. **/
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size,
-      traffic_secret, traffic_secret_size + 1, channel, &protector);
-  if (ciphersuite == kTlsChacha20Poly1305Sha256) {
-    GPR_ASSERT(create_result == TSI_UNIMPLEMENTED);
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size,
+      traffic_secret, traffic_secret_size + 1, channel_, &protector_);
+  if (GetParam() == kTlsChacha20Poly1305Sha256) {
+    EXPECT_EQ(create_result, TSI_UNIMPLEMENTED);
   } else {
-    GPR_ASSERT(create_result == TSI_FAILED_PRECONDITION);
+    EXPECT_EQ(create_result, TSI_FAILED_PRECONDITION);
   }
-  GPR_ASSERT(protector == nullptr);
+  EXPECT_EQ(protector_, nullptr);
 
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size + 1,
-      traffic_secret, traffic_secret_size, channel, &protector);
-  GPR_ASSERT(create_result == TSI_FAILED_PRECONDITION);
-  GPR_ASSERT(protector == nullptr);
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size + 1,
+      traffic_secret, traffic_secret_size, channel_, &protector_);
+  EXPECT_EQ(create_result, TSI_FAILED_PRECONDITION);
+  EXPECT_EQ(protector_, nullptr);
 
   /** Successfully create an s2a_zero_copy_grpc_protector instance. **/
   create_result = s2a_zero_copy_grpc_protector_create(
-      /* tls_version=*/0, ciphersuite, traffic_secret, traffic_secret_size,
-      traffic_secret, traffic_secret_size, channel, &protector);
-  if (ciphersuite == kTlsChacha20Poly1305Sha256) {
+      /* tls_version=*/0, GetParam(), traffic_secret, traffic_secret_size,
+      traffic_secret, traffic_secret_size, channel_, &protector_);
+  if (GetParam() == kTlsChacha20Poly1305Sha256) {
     /** The CHACHA-POLY ciphersuite is not yet supported. **/
-    GPR_ASSERT(create_result == TSI_UNIMPLEMENTED);
-    GPR_ASSERT(protector == nullptr);
+    EXPECT_EQ(create_result, TSI_UNIMPLEMENTED);
+    EXPECT_EQ(protector_, nullptr);
   } else {
-    GPR_ASSERT(create_result == TSI_OK);
-    GPR_ASSERT(protector != nullptr);
+    EXPECT_EQ(create_result, TSI_OK);
+    EXPECT_NE(protector_, nullptr);
     size_t max_protected_frame_size =
         SSL3_RT_HEADER_LENGTH + SSL3_RT_MAX_PLAIN_LENGTH + 1 + tag_size;
     size_t actual_max_protected_frame_size;
-    GPR_ASSERT(tsi_zero_copy_grpc_protector_max_frame_size(
-                   protector, &actual_max_protected_frame_size) == TSI_OK);
-    GPR_ASSERT(max_protected_frame_size == actual_max_protected_frame_size);
+    EXPECT_EQ(tsi_zero_copy_grpc_protector_max_frame_size(
+                  protector_, &actual_max_protected_frame_size),
+              TSI_OK);
+    EXPECT_EQ(max_protected_frame_size, actual_max_protected_frame_size);
   }
 
-  // Cleanup.
-  tsi_zero_copy_grpc_protector_destroy(protector);
-  delete channel;
+  /** Cleanup. **/
   grpc_core::ExecCtx::Get()->Flush();
 }
 
-static tsi_result setup_protector(uint16_t ciphersuite, grpc_channel* channel,
-                                  tsi_zero_copy_grpc_protector** protector) {
-  uint8_t* traffic_secret;
-  size_t traffic_secret_size;
-  switch (ciphersuite) {
-    case kTlsAes128GcmSha256:
-      traffic_secret = s2a_test_data::aes_128_gcm_traffic_secret.data();
-      traffic_secret_size = s2a_test_data::aes_128_gcm_traffic_secret.size();
-      break;
-    case kTlsAes256GcmSha384:
-      traffic_secret = s2a_test_data::aes_256_gcm_traffic_secret.data();
-      traffic_secret_size = s2a_test_data::aes_256_gcm_traffic_secret.size();
-      break;
-    case kTlsChacha20Poly1305Sha256:
-      traffic_secret = s2a_test_data::chacha_poly_traffic_secret.data();
-      traffic_secret_size = s2a_test_data::chacha_poly_traffic_secret.size();
-      break;
-    default:
-      gpr_log(GPR_ERROR, kS2AUnsupportedCiphersuite);
-      return TSI_UNIMPLEMENTED;
-  }
-  return s2a_zero_copy_grpc_protector_create(
-      /* TLS 1.3=*/0, ciphersuite, traffic_secret, traffic_secret_size,
-      traffic_secret, traffic_secret_size, channel, protector);
-}
-
-static void s2a_zero_copy_grpc_protector_small_protect_test(
-    uint16_t ciphersuite) {
+TEST_P(S2AFrameProtectorTest, SmallProtect) {
   grpc_core::ExecCtx exec_ctx;
-  tsi_zero_copy_grpc_protector* protector = nullptr;
-  grpc_channel* channel = new grpc_channel();
-  tsi_result create_result = setup_protector(ciphersuite, channel, &protector);
-  if (ciphersuite == kTlsChacha20Poly1305Sha256) {
-    GPR_ASSERT(create_result == TSI_UNIMPLEMENTED);
-
-    // Cleanup.
-    tsi_zero_copy_grpc_protector_destroy(protector);
-    delete channel;
-    grpc_core::ExecCtx::Get()->Flush();
+  if (!InitializeProtector()) {
     return;
   }
-  GPR_ASSERT(create_result == TSI_OK);
 
   std::vector<uint8_t> test_plaintext = {'1', '2', '3', '4', '5', '6'};
   grpc_slice test_slice = grpc_slice_from_static_buffer(test_plaintext.data(),
@@ -192,14 +217,15 @@ static void s2a_zero_copy_grpc_protector_small_protect_test(
   grpc_slice_buffer record_buffer;
   grpc_slice_buffer_init(&record_buffer);
 
-  GPR_ASSERT(tsi_zero_copy_grpc_protector_protect(protector, &plaintext_buffer,
-                                                  &record_buffer) == TSI_OK);
-  GPR_ASSERT(record_buffer.count == 1);
+  EXPECT_EQ(tsi_zero_copy_grpc_protector_protect(protector_, &plaintext_buffer,
+                                                 &record_buffer),
+            TSI_OK);
+  EXPECT_EQ(record_buffer.count, 1);
   uint8_t* record = GRPC_SLICE_START_PTR(record_buffer.slices[0]);
   size_t record_size = GRPC_SLICE_LENGTH(record_buffer.slices[0]);
   GPR_ASSERT(record_size == expected_message_size(test_plaintext.size()));
   uint8_t* correct_record;
-  switch (ciphersuite) {
+  switch (GetParam()) {
     case kTlsAes128GcmSha256:
       correct_record = s2a_test_data::aes_128_gcm_decrypt_record_1.data();
       break;
@@ -211,50 +237,38 @@ static void s2a_zero_copy_grpc_protector_small_protect_test(
       break;
   }
   for (size_t i = 0; i < record_size; i++) {
-    GPR_ASSERT(record[i] == correct_record[i]);
+    EXPECT_EQ(record[i], correct_record[i]);
   }
 
-  // Cleanup.
+  /** Cleanup. **/
   grpc_slice_buffer_destroy_internal(&plaintext_buffer);
   grpc_slice_buffer_destroy_internal(&record_buffer);
-  tsi_zero_copy_grpc_protector_destroy(protector);
-  delete channel;
   grpc_core::ExecCtx::Get()->Flush();
 }
 
-static void s2a_zero_copy_grpc_protector_empty_protect_test(
-    uint16_t ciphersuite) {
+TEST_P(S2AFrameProtectorTest, EmptyProtect) {
   grpc_core::ExecCtx exec_ctx;
-  tsi_zero_copy_grpc_protector* protector = nullptr;
-  grpc_channel* channel = new grpc_channel();
-  tsi_result create_result = setup_protector(ciphersuite, channel, &protector);
-  if (ciphersuite == kTlsChacha20Poly1305Sha256) {
-    GPR_ASSERT(create_result == TSI_UNIMPLEMENTED);
-
-    // Cleanup.
-    tsi_zero_copy_grpc_protector_destroy(protector);
-    delete channel;
-    grpc_core::ExecCtx::Get()->Flush();
+  if (!InitializeProtector()) {
     return;
   }
-  GPR_ASSERT(create_result == TSI_OK);
 
-  grpc_slice test_slice = grpc_slice_from_static_buffer(/* source=*/nullptr,
-                                                        /* length=*/0);
+  grpc_slice test_slice = grpc_slice_from_static_buffer(/*source=*/nullptr,
+                                                        /*length=*/0);
   grpc_slice_buffer plaintext_buffer;
   grpc_slice_buffer_init(&plaintext_buffer);
   grpc_slice_buffer_add(&plaintext_buffer, test_slice);
   grpc_slice_buffer record_buffer;
   grpc_slice_buffer_init(&record_buffer);
 
-  GPR_ASSERT(tsi_zero_copy_grpc_protector_protect(protector, &plaintext_buffer,
-                                                  &record_buffer) == TSI_OK);
-  GPR_ASSERT(record_buffer.count == 1);
+  EXPECT_EQ(tsi_zero_copy_grpc_protector_protect(protector_, &plaintext_buffer,
+                                                 &record_buffer),
+            TSI_OK);
+  EXPECT_EQ(record_buffer.count, 1);
   uint8_t* record = GRPC_SLICE_START_PTR(record_buffer.slices[0]);
   size_t record_size = GRPC_SLICE_LENGTH(record_buffer.slices[0]);
-  GPR_ASSERT(record_size == expected_message_size(/* plaintext_size=*/0));
+  EXPECT_EQ(record_size, expected_message_size(/*plaintext_size=*/0));
   uint8_t* correct_record;
-  switch (ciphersuite) {
+  switch (GetParam()) {
     case kTlsAes128GcmSha256:
       correct_record = s2a_test_data::aes_128_gcm_empty_record_bytes.data();
       break;
@@ -266,36 +280,24 @@ static void s2a_zero_copy_grpc_protector_empty_protect_test(
       break;
   }
   for (size_t i = 0; i < record_size; i++) {
-    GPR_ASSERT(record[i] == correct_record[i]);
+    EXPECT_EQ(record[i], correct_record[i]);
   }
 
-  // Cleanup.
+  /** Cleanup. **/
   grpc_slice_buffer_destroy_internal(&plaintext_buffer);
   grpc_slice_buffer_destroy_internal(&record_buffer);
-  tsi_zero_copy_grpc_protector_destroy(protector);
-  delete channel;
   grpc_core::ExecCtx::Get()->Flush();
 }
 
-static void s2a_zero_copy_grpc_protector_unprotect_test(uint16_t ciphersuite) {
+TEST_P(S2AFrameProtectorTest, Unprotect) {
   grpc_core::ExecCtx exec_ctx;
-  tsi_zero_copy_grpc_protector* protector = nullptr;
-  grpc_channel* channel = new grpc_channel();
-  tsi_result create_result = setup_protector(ciphersuite, channel, &protector);
-  if (ciphersuite == kTlsChacha20Poly1305Sha256) {
-    GPR_ASSERT(create_result == TSI_UNIMPLEMENTED);
-
-    // Cleanup.
-    tsi_zero_copy_grpc_protector_destroy(protector);
-    delete channel;
-    grpc_core::ExecCtx::Get()->Flush();
+  if (!InitializeProtector()) {
     return;
   }
-  GPR_ASSERT(create_result == TSI_OK);
 
   uint8_t* record;
   size_t record_size;
-  switch (ciphersuite) {
+  switch (GetParam()) {
     case kTlsAes128GcmSha256:
       record = s2a_test_data::aes_128_gcm_decrypt_record_1.data();
       record_size = s2a_test_data::aes_128_gcm_decrypt_record_1.size();
@@ -320,33 +322,29 @@ static void s2a_zero_copy_grpc_protector_unprotect_test(uint16_t ciphersuite) {
   grpc_slice_buffer plaintext_buffer;
   grpc_slice_buffer_init(&plaintext_buffer);
 
-  GPR_ASSERT(tsi_zero_copy_grpc_protector_unprotect(
-                 protector, &record_buffer, &plaintext_buffer) == TSI_OK);
-  GPR_ASSERT(plaintext_buffer.count == 1);
+  EXPECT_EQ(tsi_zero_copy_grpc_protector_unprotect(protector_, &record_buffer,
+                                                   &plaintext_buffer),
+            TSI_OK);
+  EXPECT_EQ(plaintext_buffer.count, 1);
   uint8_t* plaintext = GRPC_SLICE_START_PTR(plaintext_buffer.slices[0]);
   size_t plaintext_size = GRPC_SLICE_LENGTH(plaintext_buffer.slices[0]);
   GPR_ASSERT(plaintext_size == s2a_test_data::decrypt_plaintext_1.size());
   for (size_t i = 0; i < plaintext_size; i++) {
-    GPR_ASSERT(plaintext[i] == s2a_test_data::decrypt_plaintext_1[i]);
+    EXPECT_EQ(plaintext[i], s2a_test_data::decrypt_plaintext_1[i]);
   }
 
-  // Cleanup.
+  /** Cleanup. **/
   grpc_slice_buffer_destroy_internal(&plaintext_buffer);
   grpc_slice_buffer_destroy_internal(&record_buffer);
-  tsi_zero_copy_grpc_protector_destroy(protector);
-  delete channel;
   grpc_core::ExecCtx::Get()->Flush();
 }
 
-int main(int /** argc **/, char** /** argv **/) {
-  const size_t number_ciphersuites = 3;
-  uint16_t ciphersuite[number_ciphersuites] = {
-      kTlsAes128GcmSha256, kTlsAes256GcmSha384, kTlsChacha20Poly1305Sha256};
-  for (size_t i = 0; i < number_ciphersuites; i++) {
-    s2a_zero_copy_grpc_protector_create_test(ciphersuite[i]);
-    s2a_zero_copy_grpc_protector_small_protect_test(ciphersuite[i]);
-    s2a_zero_copy_grpc_protector_empty_protect_test(ciphersuite[i]);
-    s2a_zero_copy_grpc_protector_unprotect_test(ciphersuite[i]);
-  }
-  return 0;
+}  // namespace testing
+
+int main(int argc, char** argv) {
+  grpc_init();
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
 }

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5434,7 +5434,7 @@
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 
-    "gtest": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "s2a_frame_protector_test", 
     "platforms": [
@@ -5482,7 +5482,7 @@
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 
-    "gtest": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "s2a_record_protocol_test", 
     "platforms": [


### PR DESCRIPTION
This PR modernizes the S2A frame protector tests to use the gtest framework.
