### PR TITLE
Modernize S2A handshaker client tests.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5707,6 +5707,7 @@ targets:
   - gpr
   - grpc
 - name: s2a_handshaker_client_test
+  gtest: true
   build: test
   language: c++
   src:

--- a/test/core/tsi/s2a/BUILD
+++ b/test/core/tsi/s2a/BUILD
@@ -95,6 +95,7 @@ grpc_cc_test(
     name = "s2a_handshaker_client_test",
     srcs = ["s2a_handshaker_client_test.cc"],
     language = "C++",
+    external_deps = ["gtest"],
     deps = [
         "//:s2a_constants",
         ":s2a_test_util",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5458,7 +5458,7 @@
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 
-    "gtest": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "s2a_handshaker_client_test", 
     "platforms": [


### PR DESCRIPTION
This PR modernizes the S2A handshaker client tests to use the gtest framework.