### PR TITLE
Fix mTLS greeter server example

### DIFF
--- a/examples/cpp/helloworld/mtls_greeter_server.cc
+++ b/examples/cpp/helloworld/mtls_greeter_server.cc
@@ -21,9 +21,7 @@
 #include <memory>
 #include <string>
 
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"


### PR DESCRIPTION
Removed unnecessary includes from the mTLS greeter example.