### PR TITLE
Add S2A shared resources struct.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2699,6 +2699,7 @@ grpc_cc_library(
         "src/core/tsi/s2a/handshaker/s2a_handshaker_client.cc",
         "src/core/tsi/s2a/handshaker/s2a_handshaker_client_caller.cc",
         "src/core/tsi/s2a/handshaker/s2a_handshaker_util.cc",
+        "src/core/tsi/s2a/handshaker/s2a_shared_resource.cc",
         "src/core/tsi/s2a/handshaker/s2a_tsi_handshaker.cc",
         "src/core/tsi/s2a/util/s2a_util.cc",
         "src/core/tsi/s2a/frame_protector/s2a_zero_copy_grpc_protector.cc",
@@ -2706,6 +2707,7 @@ grpc_cc_library(
         "src/core/tsi/transport_security_grpc.cc",
     ],
     hdrs = [
+        "src/core/tsi/s2a/s2a_shared_resource.h",
         "src/core/tsi/s2a/s2a_tsi_handshaker.h",
         "src/core/tsi/s2a/grpc_s2a_credentials_options.h",
         "src/core/tsi/s2a/s2a_security.h",

--- a/src/core/tsi/s2a/handshaker/s2a_shared_resource.cc
+++ b/src/core/tsi/s2a/handshaker/s2a_shared_resource.cc
@@ -1,0 +1,84 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/tsi/s2a/s2a_shared_resource.h"
+
+#include <grpc/support/log.h>
+
+#include "src/core/tsi/s2a/handshaker/s2a_handshaker_client.h"
+
+using s2a::tsi::S2AHandshakerClient;
+
+static s2a_shared_resource_dedicated g_s2a_resource_dedicated;
+
+s2a_shared_resource_dedicated* grpc_s2a_get_shared_resource_dedicated(void) {
+  return &g_s2a_resource_dedicated;
+}
+
+static void thread_worker(void* /*arg*/) {
+  while (true) {
+    grpc_event event =
+        grpc_completion_queue_next(g_s2a_resource_dedicated.cq,
+                                   gpr_inf_future(GPR_CLOCK_REALTIME), nullptr);
+    GPR_ASSERT(event.type != GRPC_QUEUE_TIMEOUT);
+    if (event.type == GRPC_QUEUE_SHUTDOWN) {
+      break;
+    }
+    GPR_ASSERT(event.type == GRPC_OP_COMPLETE);
+    S2AHandshakerClient* client = static_cast<S2AHandshakerClient*>(event.tag);
+    GPR_ASSERT(client != nullptr);
+    client->HandleResponse(event.success);
+  }
+}
+
+void grpc_s2a_shared_resource_dedicated_init() {
+  g_s2a_resource_dedicated.cq = nullptr;
+  gpr_mu_init(&g_s2a_resource_dedicated.mu);
+}
+
+void grpc_s2a_shared_resource_dedicated_start(const char* s2a_address) {
+  gpr_mu_lock(&g_s2a_resource_dedicated.mu);
+  if (g_s2a_resource_dedicated.cq == nullptr) {
+    g_s2a_resource_dedicated.channel =
+        grpc_insecure_channel_create(s2a_address, nullptr, nullptr);
+    g_s2a_resource_dedicated.cq =
+        grpc_completion_queue_create_for_next(nullptr);
+    g_s2a_resource_dedicated.thread =
+        grpc_core::Thread("s2a_tsi_handshaker", &thread_worker, nullptr);
+    g_s2a_resource_dedicated.interested_parties = grpc_pollset_set_create();
+    grpc_pollset_set_add_pollset(g_s2a_resource_dedicated.interested_parties,
+                                 grpc_cq_pollset(g_s2a_resource_dedicated.cq));
+    g_s2a_resource_dedicated.thread.Start();
+  }
+  gpr_mu_unlock(&g_s2a_resource_dedicated.mu);
+}
+
+void grpc_s2a_shared_resource_dedicated_shutdown() {
+  if (g_s2a_resource_dedicated.cq != nullptr) {
+    grpc_pollset_set_del_pollset(g_s2a_resource_dedicated.interested_parties,
+                                 grpc_cq_pollset(g_s2a_resource_dedicated.cq));
+    grpc_completion_queue_shutdown(g_s2a_resource_dedicated.cq);
+    g_s2a_resource_dedicated.thread.Join();
+    grpc_pollset_set_destroy(g_s2a_resource_dedicated.interested_parties);
+    grpc_completion_queue_destroy(g_s2a_resource_dedicated.cq);
+    grpc_channel_destroy(g_s2a_resource_dedicated.channel);
+  }
+  gpr_mu_destroy(&g_s2a_resource_dedicated.mu);
+}

--- a/src/core/tsi/s2a/s2a_shared_resource.h
+++ b/src/core/tsi/s2a/s2a_shared_resource.h
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_CORE_TSI_S2A_S2A_SHARED_RESOURCE_H
+#define GRPC_CORE_TSI_S2A_S2A_SHARED_RESOURCE_H
+
+#include <grpc/support/port_platform.h>
+
+#include <grpc/grpc.h>
+#include <grpc/support/sync.h>
+
+#include "src/core/lib/gprpp/thd.h"
+#include "src/core/lib/iomgr/pollset_set.h"
+#include "src/core/lib/surface/completion_queue.h"
+
+/**
+ * Main struct containing S2A shared resources used when
+ * employing the dedicated completion queue and thread.
+ */
+typedef struct s2a_shared_resource_dedicated {
+  grpc_core::Thread thread;
+  grpc_completion_queue* cq;
+  grpc_pollset_set* interested_parties;
+  grpc_cq_completion storage;
+  gpr_mu mu;
+  grpc_channel* channel;
+} s2a_shared_resource_dedicated;
+
+/** Returns the address of s2a_shared_resource_dedicated object shared by all
+ *  TSI handshakes. */
+s2a_shared_resource_dedicated* grpc_s2a_get_shared_resource_dedicated(void);
+
+/** Destroys the s2a_shared_resource_dedicated object shared by all TSI
+ *  handshakes. The application is responsible for invoking the API before
+ *  calling grpc_shutdown().
+ */
+void grpc_s2a_shared_resource_dedicated_shutdown();
+
+/**
+ * Initializes the s2a_shared_resource_dedicated object
+ * shared by all TSI handshakes. The application is responsible for
+ * invoking the API after calling grpc_init();
+ */
+void grpc_s2a_shared_resource_dedicated_init();
+
+/**
+ * Populates various fields of the s2a_shared_resource_dedicated
+ * object shared by all TSI handshakes and start the dedicated thread.
+ * The API will be invoked by the caller in a lazy manner. That is,
+ * it will get invoked when S2A TSI handshake occurs for the first time.
+ */
+void grpc_s2a_shared_resource_dedicated_start(const char* s2a_address);
+
+#endif /* GRPC_CORE_TSI_S2A_S2A_SHARED_RESOURCE_H */

--- a/test/core/tsi/s2a/s2a_handshaker_client_test.cc
+++ b/test/core/tsi/s2a/s2a_handshaker_client_test.cc
@@ -29,6 +29,7 @@
 #include "src/core/tsi/s2a/handshaker/s2a_handshaker_util.h"
 #include "src/core/tsi/s2a/handshaker/s2a_tsi_test_utilities.h"
 #include "src/core/tsi/s2a/s2a_security.h"
+#include "src/core/tsi/s2a/s2a_shared_resource.h"
 #include "src/core/tsi/s2a/s2a_tsi_handshaker.h"
 #include "src/core/tsi/transport_security_grpc.h"
 #include "src/core/tsi/transport_security_interface.h"
@@ -377,7 +378,9 @@ TEST_F(S2AHandshakerClientTest, ScheduleRequestGrpcCallFailure) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
+  grpc_s2a_shared_resource_dedicated_init();
   int ret = RUN_ALL_TESTS();
+  grpc_s2a_shared_resource_dedicated_shutdown();
   grpc_shutdown();
   return ret;
 }

--- a/test/core/tsi/s2a/s2a_mock_handshake_test.cc
+++ b/test/core/tsi/s2a/s2a_mock_handshake_test.cc
@@ -34,6 +34,7 @@
 #include "src/core/tsi/s2a/handshaker/s2a_handshaker_client.h"
 #include "src/core/tsi/s2a/handshaker/s2a_tsi_test_utilities.h"
 #include "src/core/tsi/s2a/s2a_security.h"
+#include "src/core/tsi/s2a/s2a_shared_resource.h"
 #include "src/core/tsi/s2a/s2a_tsi_handshaker.h"
 #include "src/core/tsi/transport_security_grpc.h"
 #include "upb/upb.hpp"
@@ -1085,7 +1086,9 @@ TEST_F(S2AMockHandshakeTest, CheckHandshakerSuccess) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
+  grpc_s2a_shared_resource_dedicated_init();
   int ret = RUN_ALL_TESTS();
+  grpc_s2a_shared_resource_dedicated_shutdown();
   grpc_shutdown();
   return ret;
 }


### PR DESCRIPTION
This is necessary for the S2A/Envoy integration, which is built on top off of the S2A TSI implementation in the gRPC C-core.
